### PR TITLE
Add a more descriptive docstring to `bool`

### DIFF
--- a/src/Control/Error/Util.purs
+++ b/src/Control/Error/Util.purs
@@ -57,7 +57,7 @@ exceptNoteA a e = ExceptT (note e <$> a)
 
 infixl 9 exceptNoteA as !?
 
--- | Case analysis for the `Boolean` type
+-- | Case analysis for the `Boolean` type. If  the `Boolean` is false, the first case is taken, otherwise the second case is taken.
 bool :: forall a. a -> a -> Boolean -> a
 bool a b c = if c then b else a
 


### PR DESCRIPTION
Bool is arguably counter intutive because is sort of aligns the cases
as false, then true instead of the other way around. Nevertheless, the
docstring should mention how it works.