### PR TITLE
Fix license identifier in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "pulp build -I test -- --censor-lib --strict",
     "build": "pulp build -- --censor-lib --strict"
   },
-  "license": "Apache-2",
+  "license": "Apache-2.0",
   "devDependencies": {
     "pulp": "^13.0.0",
     "purescript": "0.13.3",


### PR DESCRIPTION
This PR fixes the license identifier in the `package.json` file to be a valid SPDX license identifer.

### Motivation

`errors` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.